### PR TITLE
Use PERSONAL_RELEASE_DRAFTER PAT (key) to run Release Drafter

### DIFF
--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -11,4 +11,4 @@ jobs:
     steps:
       - uses: release-drafter/release-drafter@v5
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.PERSONAL_RELEASE_DRAFTER }}


### PR DESCRIPTION
> There is a limitation of workflow: An action in a workflow run can’t trigger a new workflow run.
>
> When you use GITHUB_TOKEN in your actions, all of the interactions with the repository are on behalf of the Github-actions bot. The operations act by Github-actions bot cannot trigger a new workflow run.

https://github.community/t/github-actions-workflow-not-triggering-with-tag-push/17053/2
